### PR TITLE
fix: fix UI of the personalize button

### DIFF
--- a/lib/common/themes.dart
+++ b/lib/common/themes.dart
@@ -34,6 +34,12 @@ final ThemeData lightTheme = ThemeData(
       brightness: Brightness.light, primary: Colors.black),
   accentIconTheme: const IconThemeData(color: Colors.white),
   dividerColor: Colors.transparent,
+  textButtonTheme: TextButtonThemeData(
+    style: TextButton.styleFrom(
+      backgroundColor: const Color(0xff181926),
+      primary: Colors.white,
+    ),
+  ),
 );
 
 ThemeData bookTheme() {

--- a/lib/screens/dashboard/user_choice.dart
+++ b/lib/screens/dashboard/user_choice.dart
@@ -1,3 +1,4 @@
+import 'package:books_app/constants/colors.dart';
 import 'package:books_app/providers/user.dart';
 import 'package:books_app/screens/user_preferences.dart';
 import 'package:flutter/material.dart';
@@ -41,11 +42,13 @@ class UserChoice extends StatelessWidget {
                 padding: const EdgeInsets.all(20),
                 child: AspectRatio(
                   aspectRatio: 343 / 52,
-                  child: MaterialButton(
+                  child: TextButton(
                     child: Text(
                       'Personalize',
                       style: GoogleFonts.poppins(
-                          fontWeight: FontWeight.w500, fontSize: 16),
+                        fontWeight: FontWeight.w500,
+                        fontSize: 16,
+                      ),
                     ),
                     onPressed: () async {
                       await showGeneralDialog(
@@ -59,8 +62,10 @@ class UserChoice extends StatelessWidget {
                                   Animation<double> animation2) =>
                               UserPreference(userData));
                     },
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(16)),
+                    style: TextButton.styleFrom(
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16)),
+                    ),
                   ),
                 ),
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -49,7 +49,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   chips_choice:
     dependency: "direct main"
     description:
@@ -435,7 +435,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.3.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -664,7 +664,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.3.0"
   transparent_image:
     dependency: transitive
     description:


### PR DESCRIPTION
# Description

This is in reference to issue #86. The UI of the personalize button has been fixed for light theme. An obsolete version of MaterialButton was being used for personalize button, so I changed it to TextButton inorder to add a button theme in the light theme data. The personalize button is throwing an error  "The getter 'preferences' was called on null.", so I could not work on changing the color of use preferences buttons. Please suggest how to proceed further.

![0](https://user-images.githubusercontent.com/76617460/136006452-d0ec41d6-623b-4bdf-b1df-0bb4b3eeb804.jpg)
![0](https://user-images.githubusercontent.com/76617460/136006592-3a6da7c1-07aa-4df0-b661-8a76301171d1.jpg)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
<!-- - [ ] This change requires a documentation update -->




# Checklist:

- [x] My code follows the code of conduct of this project
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
<!-- - [ ] I have made corresponding changes to the documentation -->
- [x] My changes generate no new warnings
<!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
<!-- - [ ] New and existing unit tests pass locally with my changes -->
<!-- - [ ] Any dependent changes have been merged and published in downstream modules -->